### PR TITLE
updated build.sh and readme.md with missing instructions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-cd frontend && npm run build && cd ..
+cd frontend && npm install && npm run build && cd ..
 docker build -t janitor .

--- a/janitor/settings.py
+++ b/janitor/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = '82behp90pey-40ect&$97n#uaj%@uiqo1^rgm%vd8#8&)#5t3^'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv('JANITOR_DEBUG', 'True') == 'True'
 
-ALLOWED_HOSTS = ['localhost', '127.0.0.1', 'janitor.moview.com.ng']
+ALLOWED_HOSTS = ['localhost', '127.0.0.1', '0.0.0.0', 'janitor.moview.com.ng']
 
 
 # Application definition

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,9 @@ With Docker:
 * Access the app on port 20000.
 
 Without Docker (plain Django):
+* Create logs & backup dirs with `mkdir -p logs backups`
+* Build Frontend Artefacts with
+  `cd frontend && npm install && npm run build && cd ..`
 * Install requirements with `pip install -r requirements.txt`.
 * Start the app with `python manage.py runserver`.
 * Visit [localhost:8000](http://localhost:8000).


### PR DESCRIPTION
Hi Uk,

Both your docker & plain django run instructions were missing a few commands necessary to get this working out of the box (off a fresh clone). This makes sense as your copy would already have the `backups` & `logs` folders created and your js packages installed.

I've updated the readme.md to help anyone else who finds your project useful. :+1: 

